### PR TITLE
Define commands with <bang>

### DIFF
--- a/plugin/diffconflicts.vim
+++ b/plugin/diffconflicts.vim
@@ -73,8 +73,8 @@ function! s:checkThenDiff()
     endif
 endfunction
 
-command DiffConflicts call s:checkThenDiff()
-command DiffConflictsShowHistory call s:showHistory()
+command! DiffConflicts call s:checkThenDiff()
+command! DiffConflictsShowHistory call s:showHistory()
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
As it allows to redefine already existing command. It could be useful in case of lazy loading the plugin with a command of the same name.