### PR TITLE
Put doc/tags into .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
I believe, after https://github.com/whiteinge/diffconflicts/commit/9dcc13f9fca987a37862ed75c772b798266e52e8 you would like to ignore `doc/tags`, because otherwise it causes a problem on updating the plugin.
