### PR TITLE
Also match Windows line endings

### DIFF
--- a/plugin/diffconflicts.vim
+++ b/plugin/diffconflicts.vim
@@ -28,14 +28,14 @@ function! s:diffconfl()
     silent execute "read #". l:origBuf
     1delete
     silent execute "file RCONFL"
-    silent execute "g/^=======$/,/^>>>>>>> /d"
+    silent execute "g/^=======\\r\\?$/,/^>>>>>>> /d"
     silent execute "g/^<<<<<<< /d"
     setlocal nomodifiable readonly buftype=nofile bufhidden=delete nobuflisted
     diffthis
 
     " Set up the left-hand side.
     wincmd p
-    silent execute "g/^<<<<<<< /,/^=======$/d"
+    silent execute "g/^<<<<<<< /,/^=======\\r\\?$/d"
     silent execute "g/^>>>>>>> /d"
     diffthis
 endfunction


### PR DESCRIPTION
Why: The `$` anchor would not match if a line ended in a `^M`.

What needs this meets: Files with mixed Windows/UNIX line endings.

Possible side effects: Is the regex used here dependent on any
particular flags?