### PR TITLE
Replace getbufinfo() and lambda for ealier versions of Vim

### DIFF
--- a/plugin/diffconflicts.vim
+++ b/plugin/diffconflicts.vim
@@ -68,8 +68,17 @@ function! s:showHistory()
 endfunction
 
 function! s:checkThenShowHistory()
-    let l:xs = filter(copy(getbufinfo()), {i, x ->
-            \ x.name =~# 'BASE' || x.name =~# 'LOCAL' || x.name =~# 'REMOTE'})
+    let l:xs =
+        \ filter(
+        \   map(
+        \     filter(
+        \       range(1, bufnr('$')),
+        \       'bufexists(v:val)'
+        \     ),
+        \     'bufname(v:val)'
+        \   ),
+        \   'v:val =~# "BASE" || v:val =~# "LOCAL" || v:val =~# "REMOTE"'
+        \ )
 
     if (len(l:xs) < 3)
         echohl WarningMsg


### PR DESCRIPTION
Why: those are niceties for sure but not needed for this simple check.

What needs this meets: Should restore functionality on Vim 7.4, perhaps
earlier.

Possible side effects: None expected.