### PR TITLE
Set filetype for right split (RCONFL)

### DIFF
--- a/plugin/diffconflicts.vim
+++ b/plugin/diffconflicts.vim
@@ -21,6 +21,7 @@ endfunction
 
 function! s:diffconfl()
     let l:origBuf = bufnr("%")
+    let l:origFt = &filetype
 
     " Set up the right-hand side.
     rightb vsplit
@@ -28,6 +29,7 @@ function! s:diffconfl()
     silent execute "read #". l:origBuf
     1delete
     silent execute "file RCONFL"
+    silent execute "set filetype=". l:origFt
     silent execute "g/^<<<<<<< /,/^=======\\r\\?$/d"
     silent execute "g/^>>>>>>> /d"
     setlocal nomodifiable readonly buftype=nofile bufhidden=delete nobuflisted


### PR DESCRIPTION
Since the right split is produced on the fly with `read`, no filetype is set by default. This sets the filetype (same one as the original file), which enables, besides other things, syntax highlighting.