### PR TITLE
Support diff3 conflictStyle

### DIFF
--- a/plugin/diffconflicts.vim
+++ b/plugin/diffconflicts.vim
@@ -22,6 +22,7 @@ endfunction
 function! s:diffconfl()
     let l:origBuf = bufnr("%")
     let l:origFt = &filetype
+    let l:conflictStyle = trim(system("git config --get merge.conflictStyle"))
 
     " Set up the right-hand side.
     rightb vsplit
@@ -37,7 +38,11 @@ function! s:diffconfl()
 
     " Set up the left-hand side.
     wincmd p
-    silent execute "g/^=======\\r\\?$/,/^>>>>>>> /d"
+    if l:conflictStyle == "diff3"
+        silent execute "g/^||||||| \\?/,/^>>>>>>> /d"
+    else
+        silent execute "g/^=======\\r\\?$/,/^>>>>>>> /d"
+    endif
     silent execute "g/^<<<<<<< /d"
     diffthis
 endfunction

--- a/plugin/diffconflicts.vim
+++ b/plugin/diffconflicts.vim
@@ -22,7 +22,7 @@ endfunction
 function! s:diffconfl()
     let l:origBuf = bufnr("%")
     let l:origFt = &filetype
-    let l:conflictStyle = trim(system("git config --get merge.conflictStyle"))
+    let l:conflictStyle = system("git config --get merge.conflictStyle")[:-2]
 
     " Set up the right-hand side.
     rightb vsplit


### PR DESCRIPTION
This adds support for Git's diff3 style conflict markers by simply
ignoring the section that refers to the base version. Diff3 is already
supported through the `:DiffConflictsShowHistory` command.

Note: This requires Vim 8.0.1630 right now, due to `trim()`. If you intend to support older versions, I could adjust that.

Fixes #2