### PR TITLE
Added support for Mercurial to the plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Configure Mercurial to use diffconflicts as a mergetool by adding:
 
     [merge-tools]
     diffconflicts.executable=vim
-    diffconflicts.args=-c 'let g:diffconflicts_vcs="hg"' -c DiffConflicts "$output" "$base" "$local" "$other"
+    diffconflicts.args=-c 'let g:diffconflicts_vcs="hg"' -c DiffConflicts "$output" $base $local $other
     diffconflicts.premerge=keep
     diffconflicts.check=conflicts
     diffconflicts.priority=99
@@ -107,6 +107,6 @@ Configure Mercurial to use diffconflicts as a mergetool by adding:
 to your `.hgrc` file.
 Or, if you prefer to always open both the diff view and the history view use
 
-    diffconflicts.args=-c 'let g:diffconflicts_vcs="hg"' -c DiffConflictsWithHistory "$output" "$base" "$local" "$other"
+    diffconflicts.args=-c 'let g:diffconflicts_vcs="hg"' -c DiffConflictsWithHistory "$output" $base $local $other
 
 as the args setting to call `DiffConflictsWithHistory`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vim-diffconflicts
 
-A better Vimdiff Git mergetool
+A better Vimdiff Git (and Mercurial)  mergetool
 
 tl;dr:
 
@@ -91,3 +91,26 @@ splitting them apart.
     changes.
 
     This tab is not opened by default so that Vim starts more quickly.
+
+
+## Mercurial
+
+Configure Mercurial to use diffconflicts as a mergetool by adding:
+
+    ```
+    [merge-tools]
+    diffconflicts.executable=vim
+    diffconflicts.args=-c 'let g:diffconflicts_vcs="hg"' -c DiffConflicts "$output" "$base" "$local" "$other"
+    diffconflicts.premerge=keep
+    diffconflicts.check=conflicts
+    diffconflicts.priority=99
+    ```
+
+to your `.hgrc` file.
+Or, if you prefer to always open both the diff view and the history view use
+
+    ```
+    diffconflicts.args=-c 'let g:diffconflicts_vcs="hg"' -c DiffConflictsWithHistory "$output" "$base" "$local" "$other"
+    ```
+
+as the args setting to call `DiffConflictsWithHistory`.

--- a/README.md
+++ b/README.md
@@ -97,20 +97,16 @@ splitting them apart.
 
 Configure Mercurial to use diffconflicts as a mergetool by adding:
 
-    ```
     [merge-tools]
     diffconflicts.executable=vim
     diffconflicts.args=-c 'let g:diffconflicts_vcs="hg"' -c DiffConflicts "$output" "$base" "$local" "$other"
     diffconflicts.premerge=keep
     diffconflicts.check=conflicts
     diffconflicts.priority=99
-    ```
 
 to your `.hgrc` file.
 Or, if you prefer to always open both the diff view and the history view use
 
-    ```
     diffconflicts.args=-c 'let g:diffconflicts_vcs="hg"' -c DiffConflictsWithHistory "$output" "$base" "$local" "$other"
-    ```
 
 as the args setting to call `DiffConflictsWithHistory`.

--- a/_utils/make-conflicts_hg.sh
+++ b/_utils/make-conflicts_hg.sh
@@ -20,23 +20,6 @@ hg bookmark master
 hg commit -m 'Commit One'
 
 cat << EOF > poem.txt
-twas brillig, and the slithy toves
-Did gyre and gimble in the wabe:
-all mimsy were the borogoves,
-And the mome raths outgrabe.
-
-"Beware the Jabberwock, my son!
-The jaws that bite, the claws that catch!
-Beware the Jubjub bird, and shun
-The frumious Bandersnatch!"
-EOF
-
-hg bookmark branchA
-hg commit -m 'Fix syntax mistakes'
-
-hg update -Cr master
-
-cat << EOF > poem.txt
 'Twas brillig, and the slithy toves
 Did gyre and gimble in the wabe:
 All mimsy were the borogroves
@@ -48,6 +31,22 @@ Beware the Jub jub bird, and shun
 The frumious bandersnatch!"
 EOF
 
+hg bookmark branchA
 hg commit -m 'Buncha fixes'
+
+
+hg update -Cr master
+cat << EOF > poem.txt
+twas brillig, and the slithy toves
+Did gyre and gimble in the wabe:
+all mimsy were the borogoves,
+And the mome raths outgrabe.
+
+"Beware the Jabberwock, my son!
+The jaws that bite, the claws that catch!
+Beware the Jubjub bird, and shun
+The frumious Bandersnatch!"
+EOF
+hg commit -m 'Fix syntax mistakes'
 
 hg --config ui.merge=internal:merge merge branchA

--- a/_utils/make-conflicts_hg.sh
+++ b/_utils/make-conflicts_hg.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+hg init testrepo_hg
+cd testrepo_hg
+
+cat << EOF > poem.txt
+twas bri1lig, and the slithy toves
+did gyre and gimble in the wabe
+all mimsy were the borogroves
+and the m0me raths outgabe.
+
+"Beware the Jabberwock, my son!
+The jaws that bite, the claws that catch!
+Beware the Jub jub bird, and shun
+The frumious bandersnatch!"
+EOF
+
+hg add poem.txt
+hg bookmark master
+hg commit -m 'Commit One'
+
+cat << EOF > poem.txt
+twas brillig, and the slithy toves
+Did gyre and gimble in the wabe:
+all mimsy were the borogoves,
+And the mome raths outgrabe.
+
+"Beware the Jabberwock, my son!
+The jaws that bite, the claws that catch!
+Beware the Jubjub bird, and shun
+The frumious Bandersnatch!"
+EOF
+
+hg bookmark branchA
+hg commit -m 'Fix syntax mistakes'
+
+hg update -Cr master
+
+cat << EOF > poem.txt
+'Twas brillig, and the slithy toves
+Did gyre and gimble in the wabe:
+All mimsy were the borogroves
+And the mome raths outgabe.
+
+"Beware the Jabberwock, my son!
+The jaws that bite, the claws that catch!
+Beware the Jub jub bird, and shun
+The frumious bandersnatch!"
+EOF
+
+hg commit -m 'Buncha fixes'
+
+hg --config ui.merge=internal:merge merge branchA

--- a/doc/diffconflicts.txt
+++ b/doc/diffconflicts.txt
@@ -1,4 +1,4 @@
-*diffconflicts.txt*	A better Vimdiff Git mergetool
+*diffconflicts.txt*	A better Vimdiff Git/Mercurial mergetool
 
 This plugin converts a file containing Git conflict markers into a two-way diff
 in Vimdiff. Additional mappings can be given to see the full three-way diff.
@@ -9,6 +9,14 @@ git config --global merge.tool diffconflicts
 git config --global mergetool.diffconflicts.cmd 'vim -c DiffConflicts "$MERGED" "$BASE" "$LOCAL" "$REMOTE"'
 git config --global mergetool.diffconflicts.trustExitCode true
 git config --global mergetool.keepBackup false
+
+For Mercurial use the following settings in your .hgrc:
+
+[merge-tools]
+diffconflicts.executable=vim
+diffconflicts.args=-c 'let g:diffconflicts_vcs="hg"' -c DiffConflicts "$output" "$base" "$local" "$other"
+diffconflicts.premerge=keep
+diffconflicts.check=conflicts
 
 Commands:
 :DiffConflicts
@@ -23,4 +31,5 @@ Commands:
 	the Git mergetool configuration to always open the history by default.
 
 						*DiffConflicts-settings*
-This plugin doesn't have any settings.
+        Use g:diffconflicts_vcs to indicate which version control system produced
+        the conflict file (Git or Mercurial).

--- a/doc/diffconflicts.txt
+++ b/doc/diffconflicts.txt
@@ -14,7 +14,7 @@ For Mercurial use the following settings in your .hgrc:
 
 [merge-tools]
 diffconflicts.executable=vim
-diffconflicts.args=-c 'let g:diffconflicts_vcs="hg"' -c DiffConflicts "$output" "$base" "$local" "$other"
+diffconflicts.args=-c 'let g:diffconflicts_vcs="hg"' -c DiffConflicts "$output" $base $local $other
 diffconflicts.premerge=keep
 diffconflicts.check=conflicts
 

--- a/plugin/diffconflicts.vim
+++ b/plugin/diffconflicts.vim
@@ -70,17 +70,32 @@ function! s:showHistory()
     wincmd h
 
     " Populate each window.
-    buffer LOCAL
+    if g:diffconflicts_vcs == "hg"
+        buffer ~local.
+        file LOCAL
+    else
+        buffer LOCAL
+    endif
     setlocal nomodifiable readonly
     diffthis
 
     wincmd l
-    buffer BASE
+    if g:diffconflicts_vcs == "hg"
+        buffer ~base.
+        file BASE
+    else
+        buffer BASE
+    endif
     setlocal nomodifiable readonly
     diffthis
 
     wincmd l
-    buffer REMOTE
+    if g:diffconflicts_vcs == "hg"
+        buffer ~other.
+        file OTHER
+    else
+        buffer REMOTE
+    endif
     setlocal nomodifiable readonly
     diffthis
 
@@ -89,6 +104,11 @@ function! s:showHistory()
 endfunction
 
 function! s:checkThenShowHistory()
+    if g:diffconflicts_vcs == "hg"
+        let l:filecheck = 'v:val =~# "\\~base\\." || v:val =~# "\\~local\\." || v:val =~# "\\~other\\."'
+    else
+        let l:filecheck = 'v:val =~# "BASE" || v:val =~# "LOCAL" || v:val =~# "REMOTE"'
+    endif
     let l:xs =
         \ filter(
         \   map(
@@ -98,7 +118,7 @@ function! s:checkThenShowHistory()
         \     ),
         \     'bufname(v:val)'
         \   ),
-        \   'v:val =~# "BASE" || v:val =~# "LOCAL" || v:val =~# "REMOTE"'
+        \   l:filecheck
         \ )
 
     if (len(l:xs) < 3)

--- a/plugin/diffconflicts.vim
+++ b/plugin/diffconflicts.vim
@@ -10,6 +10,13 @@ let g:loaded_diffconflicts = 1
 let s:save_cpo = &cpo
 set cpo&vim
 
+" CONFIGURATION
+if !exists("g:diffconflicts_vcs")
+    " Default to git
+    let g:diffconflicts_vcs = "git"
+endif
+
+let g:loaded_diffconflicts = 1
 function! s:hasConflicts()
     try
         silent execute "%s/^<<<<<<< //gn"
@@ -22,7 +29,14 @@ endfunction
 function! s:diffconfl()
     let l:origBuf = bufnr("%")
     let l:origFt = &filetype
-    let l:conflictStyle = system("git config --get merge.conflictStyle")[:-2]
+
+    if g:diffconflicts_vcs == "git"
+        " Obtain the git setting for the conflict style.
+        let l:conflictStyle = system("git config --get merge.conflictStyle")[:-2]
+    else
+        " Assume 2way conflict style otherwise.
+        let l:conflictStyle = "diff"
+    endif
 
     " Set up the right-hand side.
     rightb vsplit


### PR DESCRIPTION
Hi, I slightly changed the script to better fit my needs when working with Mercurial.
May also be of general interest. Thus this pull request...

Basically, this just removes the unconditional reliance on the
git executable for the diff3 checking and introduces the
variable `g:diffconflicts_vcs` to decide whether to call git
or not.
Aside from this small change, there is just the documentation
added on how to utilize this plugin in Mercurial.