### PR TITLE
Run diffthis before editing files to avoid foldmethod problem

### DIFF
--- a/plugin/diffconflicts.vim
+++ b/plugin/diffconflicts.vim
@@ -45,20 +45,22 @@ function! s:diffconfl()
     1delete
     silent execute "file RCONFL"
     silent execute "set filetype=". l:origFt
+    diffthis " set foldmethod before editing
     silent execute "g/^<<<<<<< /,/^=======\\r\\?$/d"
     silent execute "g/^>>>>>>> /d"
     setlocal nomodifiable readonly buftype=nofile bufhidden=delete nobuflisted
-    diffthis
 
     " Set up the left-hand side.
     wincmd p
+    diffthis " set foldmethod before editing
     if l:conflictStyle ==? "diff3" || l:conflictStyle ==? "zdiff3"
         silent execute "g/^||||||| \\?/,/^>>>>>>> /d"
     else
         silent execute "g/^=======\\r\\?$/,/^>>>>>>> /d"
     endif
     silent execute "g/^<<<<<<< /d"
-    diffthis
+
+    diffupdate
 endfunction
 
 function! s:showHistory()


### PR DESCRIPTION
If `foldmethod=syntax` it somehow affects the contents the deletes will operate on. No idea why. Running `diffthis` will set `foldmethod=diff` so if we do that before making the edits we should avoid the problem.

Thanks to @giuseppelettieri for identifying the problem and steps to reproduce it.

Closes #28